### PR TITLE
Habitat package for elasticsearch 7.9.1

### DIFF
--- a/elasticsearch-odfe/default.toml
+++ b/elasticsearch-odfe/default.toml
@@ -12,8 +12,6 @@
       high = "90%"
       flood_stage = "95%"
 
-  [es_yaml.discovery.zen]
-    minimum_master_nodes = 1
 
   [es_yaml.http]
     port = 9200

--- a/elasticsearch-odfe/default.toml
+++ b/elasticsearch-odfe/default.toml
@@ -12,6 +12,8 @@
       high = "90%"
       flood_stage = "95%"
 
+  [es_yaml.discovery]
+    seed_hosts = 127.0.0.1
 
   [es_yaml.http]
     port = 9200

--- a/elasticsearch-odfe/default.toml
+++ b/elasticsearch-odfe/default.toml
@@ -12,8 +12,8 @@
       high = "90%"
       flood_stage = "95%"
 
-  [es_yaml.discovery]
-    seed_hosts = 127.0.0.1
+    [es_yaml.discovery]
+      type = "single-node" #For standalone
 
   [es_yaml.http]
     port = 9200
@@ -29,7 +29,7 @@
 
   [es_yaml.node]
     max_local_storage_nodes = 1
-
+  
   [es_yaml.path]
     data = "/hab/svc/elasticsearch-odfe/data"
     logs = "/hab/svc/elasticsearch-odfe/logs"

--- a/elasticsearch-odfe/plan.sh
+++ b/elasticsearch-odfe/plan.sh
@@ -1,23 +1,23 @@
-#This is the version that the current ODFE package depends on
+# This is the version that the current ODFE package depends on
 ELASTICSEARCH_VERSION="7.9.1"
-ELASTICSEARCH_PKG_URL="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$ELASTICSEARCH_VERSION-linux-aarch64.tar.gz"
+ELASTICSEARCH_PKG_URL="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-$ELASTICSEARCH_VERSION-linux-x86_64.tar.gz"
 pkg_version=1.11.0.0
 ELASTICSEARCH_PLUGINS=(
   repository-s3
   repository-gcs
 )
-pkg_name="ff-es-odfe"
+pkg_name="elasticsearch-odfe"
 pkg_description="Open Distro for Elasticsearch plugins"
-pkg_origin="ff"
-vendor_origin="ff"
+pkg_origin="chef"
+vendor_origin="chef"
 pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_license=("Chef-MLSA")
 pkg_upstream_url="https://github.com/opendistro-for-elasticsearch"
 pkg_build_deps=(
   core/coreutils
   core/git
-  core/openjdk11
   core/maven
+  core/openjdk11
   core/openssl
   core/zip
 )
@@ -45,7 +45,7 @@ pkg_exports=(
 pkg_exposes=(http-port transport-port)
 
 do_download() {
-  wget -O "${HAB_CACHE_SRC_PATH}/elasticsearch-${ELASTICSEARCH_VERSION}-linux-aarch64.tar.gz" "${ELASTICSEARCH_PKG_URL}"
+  wget -O "${HAB_CACHE_SRC_PATH}/elasticsearch-oss-${ELASTICSEARCH_VERSION}-linux-x86_64.tar.gz" "${ELASTICSEARCH_PKG_URL}"
   rm -rf ${HAB_CACHE_SRC_PATH}/security
   git clone https://github.com/opendistro-for-elasticsearch/security.git "${HAB_CACHE_SRC_PATH}/security"
 
@@ -56,7 +56,7 @@ do_download() {
 }
 
 do_unpack() {
-  tar -xzf "${HAB_CACHE_SRC_PATH}/elasticsearch-${ELASTICSEARCH_VERSION}-linux-aarch64.tar.gz" -C "${HAB_CACHE_SRC_PATH}/"
+  tar -xzf "${HAB_CACHE_SRC_PATH}/elasticsearch-oss-${ELASTICSEARCH_VERSION}-linux-x86_64.tar.gz" -C "${HAB_CACHE_SRC_PATH}/"
 }
 
 do_build() {
@@ -91,6 +91,3 @@ do_install() {
   done
 }
 
-do_strip() {
-	
-}

--- a/elasticsearch-odfe/plan.sh
+++ b/elasticsearch-odfe/plan.sh
@@ -1,7 +1,7 @@
  This is the version that the current ODFE package depends on
 ELASTICSEARCH_VERSION="7.9.1"
 ELASTICSEARCH_PKG_URL="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$ELASTICSEARCH_VERSION-linux-aarch64.tar.gz"
-pkg_version=1.10.1
+pkg_version=1.11.0.0
 ELASTICSEARCH_PLUGINS=(
   repository-s3
   repository-gcs

--- a/elasticsearch-odfe/plan.sh
+++ b/elasticsearch-odfe/plan.sh
@@ -1,23 +1,23 @@
-# This is the version that the current ODFE package depends on
-ELASTICSEARCH_VERSION="6.8.6"
-ELASTICSEARCH_PKG_URL="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-$ELASTICSEARCH_VERSION.tar.gz"
+ This is the version that the current ODFE package depends on
+ELASTICSEARCH_VERSION="7.9.1"
+ELASTICSEARCH_PKG_URL="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$ELASTICSEARCH_VERSION-linux-aarch64.tar.gz"
 pkg_version=0.10.1.2
 ELASTICSEARCH_PLUGINS=(
   repository-s3
   repository-gcs
 )
-pkg_name="elasticsearch-odfe"
+pkg_name="ff-es-odfe"
 pkg_description="Open Distro for Elasticsearch plugins"
-pkg_origin="chef"
-vendor_origin="chef"
+pkg_origin="ff"
+vendor_origin="ff"
 pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_license=("Chef-MLSA")
 pkg_upstream_url="https://github.com/opendistro-for-elasticsearch"
 pkg_build_deps=(
   core/coreutils
   core/git
-  core/maven
   core/openjdk11
+  core/maven
   core/openssl
   core/zip
 )
@@ -45,7 +45,7 @@ pkg_exports=(
 pkg_exposes=(http-port transport-port)
 
 do_download() {
-  wget -O "${HAB_CACHE_SRC_PATH}/elasticsearch-oss-${ELASTICSEARCH_VERSION}.tar.gz" "${ELASTICSEARCH_PKG_URL}"
+  wget -O "${HAB_CACHE_SRC_PATH}/elasticsearch-${ELASTICSEARCH_VERSION}-linux-aarch64.tar.gz" "${ELASTICSEARCH_PKG_URL}"
   rm -rf ${HAB_CACHE_SRC_PATH}/security
   git clone https://github.com/opendistro-for-elasticsearch/security.git "${HAB_CACHE_SRC_PATH}/security"
 
@@ -56,7 +56,7 @@ do_download() {
 }
 
 do_unpack() {
-  tar -xzf "${HAB_CACHE_SRC_PATH}/elasticsearch-oss-${ELASTICSEARCH_VERSION}.tar.gz" -C "${HAB_CACHE_SRC_PATH}/"
+  tar -xzf "${HAB_CACHE_SRC_PATH}/elasticsearch-${ELASTICSEARCH_VERSION}-linux-aarch64.tar.gz" -C "${HAB_CACHE_SRC_PATH}/"
 }
 
 do_build() {
@@ -73,14 +73,14 @@ do_build() {
 }
 
 do_install() {
-  install -vDm644 "${HAB_CACHE_SRC_PATH}/elasticsearch-${ELASTICSEARCH_VERSION}/README.textile" "${pkg_prefix}/README.textile"
+  install -vDm644 "${HAB_CACHE_SRC_PATH}/elasticsearch-${ELASTICSEARCH_VERSION}/README.asciidoc" "${pkg_prefix}/README.asciidoc"
   install -vDm644 "${HAB_CACHE_SRC_PATH}/elasticsearch-${ELASTICSEARCH_VERSION}/LICENSE.txt" "${pkg_prefix}/LICENSE.txt"
   install -vDm644 "${HAB_CACHE_SRC_PATH}/elasticsearch-${ELASTICSEARCH_VERSION}/NOTICE.txt" "${pkg_prefix}/NOTICE.txt"
 
   cp -a "${HAB_CACHE_SRC_PATH}/elasticsearch-${ELASTICSEARCH_VERSION}/"* "${pkg_prefix}/"
 
   # Delete unused binaries to save space
-  rm "${pkg_prefix}/bin/"*.bat "${pkg_prefix}/bin/"*.exe
+  rm -f "${pkg_prefix}/bin/"*.bat "${pkg_prefix}/bin/"*.exe
 
   fix_interpreter "${pkg_prefix}/bin/*" core/bash bin/bash
   mkdir -p "${pkg_prefix}/plugins/opendistro_security"

--- a/elasticsearch-odfe/plan.sh
+++ b/elasticsearch-odfe/plan.sh
@@ -1,7 +1,7 @@
  This is the version that the current ODFE package depends on
 ELASTICSEARCH_VERSION="7.9.1"
 ELASTICSEARCH_PKG_URL="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$ELASTICSEARCH_VERSION-linux-aarch64.tar.gz"
-pkg_version=0.10.1.2
+pkg_version=1.10.1
 ELASTICSEARCH_PLUGINS=(
   repository-s3
   repository-gcs

--- a/elasticsearch-odfe/plan.sh
+++ b/elasticsearch-odfe/plan.sh
@@ -1,4 +1,4 @@
- This is the version that the current ODFE package depends on
+#This is the version that the current ODFE package depends on
 ELASTICSEARCH_VERSION="7.9.1"
 ELASTICSEARCH_PKG_URL="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$ELASTICSEARCH_VERSION-linux-aarch64.tar.gz"
 pkg_version=1.11.0.0
@@ -89,4 +89,8 @@ do_install() {
     mkdir -p "${pkg_prefix}/plugins/${plugin}"
     unzip "${HAB_CACHE_SRC_PATH}/${plugin}.zip" -d "${pkg_prefix}/plugins/${plugin}"
   done
+}
+
+do_strip() {
+	
 }


### PR DESCRIPTION
Creating Habitat package with elasticsearch-odfe version 1.11.0 which is pulling elasticsearch version 7.9.1

## Description
It will upgrade the elasticsearch version to 7.9.1 and to opendistro version 1.11.0 , so will update habitat package chef/elasticsearch-odfe

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://github.com/chef/a2-ha-backend/pull/461

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
