### PR TITLE
Matching elasticsearch version with Automate

### DIFF
--- a/elasticsearch-odfe/plan.sh
+++ b/elasticsearch-odfe/plan.sh
@@ -1,5 +1,5 @@
 # This is the version that the current ODFE package depends on
-ELASTICSEARCH_VERSION="6.8.6"
+ELASTICSEARCH_VERSION="6.8.14"
 ELASTICSEARCH_PKG_URL="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-$ELASTICSEARCH_VERSION.tar.gz"
 pkg_version=0.10.1.2
 ELASTICSEARCH_PLUGINS=(

--- a/kibana-odfe/plan.sh
+++ b/kibana-odfe/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=kibana-odfe
-KIBANA_VERSION="6.8.6"
+KIBANA_VERSION="6.8.14"
 KIBANA_PKG_URL="https://artifacts.elastic.co/downloads/kibana/kibana-oss-$KIBANA_VERSION-linux-x86_64.tar.gz"
 pkg_version="0.10.0.4"
 opendistro_version="0.10.1.2"


### PR DESCRIPTION
Signed-off-by: Andrew Dufour <adufour@chef.io>

## Description

Upgrades ElasticSearch to match Automate's version.

Allows us to restore backups from standalone automate to HA Cluster.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
