### PR TITLE
bump version of components to 6.8.22 from 6.8.6

### DIFF
--- a/elasticsearch-odfe/plan.sh
+++ b/elasticsearch-odfe/plan.sh
@@ -1,5 +1,5 @@
 # This is the version that the current ODFE package depends on
-ELASTICSEARCH_VERSION="6.8.6"
+ELASTICSEARCH_VERSION="6.8.22"
 ELASTICSEARCH_PKG_URL="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-$ELASTICSEARCH_VERSION.tar.gz"
 pkg_version=0.10.1.2
 ELASTICSEARCH_PLUGINS=(
@@ -21,7 +21,7 @@ pkg_build_deps=(
   core/openssl
   core/zip
 )
-pkg_deps=( 
+pkg_deps=(
   core/bash
   core/coreutils
   core/curl

--- a/journalbeat/plan.sh
+++ b/journalbeat/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=journalbeat
 pkg_origin=chef
-pkg_version=6.8.6
+pkg_version=6.8.22
 pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_license=("Apache-2.0")
 pkg_deps=(core/glibc core/systemd)
@@ -28,8 +28,9 @@ do_build() {
     n=$((n+1))
     sleep 1
   done
-  pushd "${HAB_CACHE_SRC_PATH}/github.com/elastic/beats/journalbeat" > /dev/null || exit 1
+  pushd "${HAB_CACHE_SRC_PATH}/github.com/elastic/beats" > /dev/null || exit 1
   git checkout "v${pkg_version}"
+  pushd "${HAB_CACHE_SRC_PATH}/github.com/elastic/beats/journalbeat" > /dev/null || exit 1
   CGO_CFLAGS="-I${SYSTEMD_INCLUDE_PATH}" go build github.com/elastic/beats/journalbeat
   popd > /dev/null || exit 1
 }

--- a/kibana-odfe/plan.sh
+++ b/kibana-odfe/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=kibana-odfe
-KIBANA_VERSION="6.8.6"
+KIBANA_VERSION="6.8.22"
 KIBANA_PKG_URL="https://artifacts.elastic.co/downloads/kibana/kibana-oss-$KIBANA_VERSION-linux-x86_64.tar.gz"
 pkg_version="0.10.0.4"
 opendistro_version="0.10.1.2"

--- a/metricbeat/plan.sh
+++ b/metricbeat/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=metricbeat
 pkg_origin="chef"
-pkg_version=6.8.6
+pkg_version=6.8.22
 pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_license=("Apache-2.0")
 pkg_deps=(core/glibc)


### PR DESCRIPTION
Signed-off-by: Collin McNeese <cmcneese@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
- Bump components to version `6.8.22`
- Update `journalbeat` plan to pushd after git checkout as `journalbeat` path has been removed from repo in latest versions.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
