### PR TITLE
Update to Elasticsearch 6.8.22

### DIFF
--- a/journalbeat/plan.sh
+++ b/journalbeat/plan.sh
@@ -28,8 +28,9 @@ do_build() {
     n=$((n+1))
     sleep 1
   done
-  pushd "${HAB_CACHE_SRC_PATH}/github.com/elastic/beats/journalbeat" > /dev/null || exit 1
+  pushd "${HAB_CACHE_SRC_PATH}/github.com/elastic/beats" > /dev/null || exit 1
   git checkout "v${pkg_version}"
+  pushd "${HAB_CACHE_SRC_PATH}/github.com/elastic/beats/journalbeat" > /dev/null || exit 1
   CGO_CFLAGS="-I${SYSTEMD_INCLUDE_PATH}" go build github.com/elastic/beats/journalbeat
   popd > /dev/null || exit 1
 }

--- a/journalbeat/plan.sh
+++ b/journalbeat/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=journalbeat
 pkg_origin=chef
-pkg_version=6.8.6
+pkg_version=6.8.22
 pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_license=("Apache-2.0")
 pkg_deps=(core/glibc core/systemd)

--- a/kibana-odfe/plan.sh
+++ b/kibana-odfe/plan.sh
@@ -1,8 +1,8 @@
 pkg_name=kibana-odfe
-KIBANA_VERSION="6.8.6"
+KIBANA_VERSION="6.8.22"
 KIBANA_PKG_URL="https://artifacts.elastic.co/downloads/kibana/kibana-oss-$KIBANA_VERSION-linux-x86_64.tar.gz"
-pkg_version="0.10.0.4"
-opendistro_version="0.10.1.2"
+pkg_version="0.10.1.1"
+opendistro_version="0.10.22.0"
 nvm_version="0.35.3"
 pkg_origin="chef"
 pkg_license=('Apache-2.0')
@@ -40,7 +40,7 @@ do_download() {
   rm -rf $HAB_CACHE_SRC_PATH/deprecated-security-parent
   git clone https://github.com/opendistro-for-elasticsearch/deprecated-security-parent.git $HAB_CACHE_SRC_PATH/deprecated-security-parent
   rm -rf $HAB_CACHE_SRC_PATH/security-kibana-plugin
-  git clone https://github.com/opendistro-for-elasticsearch/security-kibana-plugin.git $HAB_CACHE_SRC_PATH/security-kibana-plugin
+  git clone https://github.com/opensearch-project/security-dashboards-plugin.git $HAB_CACHE_SRC_PATH/security-kibana-plugin
 }
 
 do_unpack() {
@@ -67,18 +67,18 @@ do_build() {
   # The 6.8 version of this plugin deps on the now deprecated security-parent plugin.
   # This can be removed once we go to 7.X
   pushd /hab/cache/src/deprecated-security-parent>/dev/null || exit 1
-  git checkout tags/v${pkg_version}
+  git checkout origin/opendistro-0.10
   mvn compile -Dmaven.test.skip=true
   mvn package -Dmaven.test.skip=true
   mvn install -Dmaven.test.skip=true
   popd || exit 1
 
-  # Build the Kibana plugin itself. We're using opendistro 0.10.0.6, but 0.10.0.4 is as close as exists for kibana
+  # Build the Kibana plugin itself.
   pushd /hab/cache/src/security-kibana-plugin>/dev/null || exit 1
-  git checkout tags/v${pkg_version}
+  git checkout opendistro-0.10
 
   # Swap the hardcoded 6.8.1 version for 6.8.6
-  sed -i 's/6.8.1/6.8.6/g' package.json
+  sed -i "s/6.8.6/${KIBANA_VERSION}/g" package.json
 
   # This will fail, but sets up enough of an environment to not fail again
   ./build.sh ${KIBANA_VERSION} ${opendistro_version} install || true

--- a/metricbeat/plan.sh
+++ b/metricbeat/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=metricbeat
 pkg_origin="chef"
-pkg_version=6.8.6
+pkg_version=6.8.22
 pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_license=("Apache-2.0")
 pkg_deps=(core/glibc)


### PR DESCRIPTION
- Update all packages to ES 6.8.22

elasticsearch-odfe:
- Use the newer opensearch-project/security repository
- Change the security plugin ES version to 6.8.22
- Use HEAD of the opendistro-0.10 branch for any patches
- Ensure that hab can run the tools/securityadmin.sh script
- Changed the package version to arbitrary 0.10.22.0 to represent 6.8.22

kibana-odfe:
- Use the newer opensearch-project/security-dashboards-plugin
- Use HEAD of the opendistro-0.10 branch for any patches

```
$ curl  https://127.0.0.1:9200 --insecure -u admin:admin
{
  "name" : "gABUx5m",
  "cluster_name" : "chef-insights",
  "cluster_uuid" : "sBGR_rP4Q0aPZBt9TL_t-A",
  "version" : {
    "number" : "6.8.22",
    "build_flavor" : "oss",
    "build_type" : "tar",
    "build_hash" : "71fcb50",
    "build_date" : "2021-12-19T01:10:56.497443Z",
    "build_snapshot" : false,
    "lucene_version" : "7.7.3",
    "minimum_wire_compatibility_version" : "5.6.0",
    "minimum_index_compatibility_version" : "5.0.0"
  },
  "tagline" : "You Know, for Search"
}
```

![image](https://user-images.githubusercontent.com/4381/147170147-862d2f5f-9310-4fa5-a915-1a74a186a1a4.png)


```
elasticsearch-odfe.default(O): [2021-12-22T19:19:57,175][INFO ][o.e.c.r.a.AllocationService] [gABUx5m] Cluster health status changed from [YELLOW] to [GREEN] (reason: [shards started [[.kibana_1][0]] ...]).
kibana-odfe.default(O): {"type":"log","@timestamp":"2021-12-23T00:19:57Z","tags":["listening","info"],"pid":2564557,"message":"Server running at https://0.0.0.0:5601"}
```

Note for Kibana I had to add `elasticsearch.ssl.verificationMode: none` for this to work locally in this configuration due to:
```
kibana-odfe.default(O): {"type":"log","@timestamp":"2021-12-23T00:15:54Z","tags":["error","elasticsearch","admin"],"pid":2564140,"message":"Request error, retrying\nHEAD https://localhost:9200/ => Hostname/IP does not match certificate's altnames: Host: localhost. is not cert's CN: node"}
```

I did this by hacking the `default.toml` locally after install.

These messages may be worth looking into as a followup:
```
kibana-odfe.default(O): {"type":"log","@timestamp":"2021-12-23T00:15:52Z","tags":["warning","elasticsearch","config","deprecation"],"pid":2564140,"message":"Config key \"url\" is deprecated. It has been replaced with \"hosts\""}
kibana-odfe.default(O): {"type":"log","@timestamp":"2021-12-23T00:15:53Z","tags":["status","plugin:opendistro_security@6.8.22","info"],"pid":2564140,"state":"yellow","message":"Status changed from yellow to yellow - 'opendistro_security.cookie.secure' is set to false, cookies are transmitted over unsecure HTTP connection. Consider using HTTPS and set this key to 'true'","prevState":"yellow","prevMsg":"Default cookie password detected, please set a password in kibana.yml by setting 'opendistro_security.cookie.password' (min. 32 characters)."}
```